### PR TITLE
Suppress the warning in Xcode

### DIFF
--- a/src/ios/METEORCordovaURLProtocol.m
+++ b/src/ios/METEORCordovaURLProtocol.m
@@ -12,6 +12,10 @@ NSDictionary *MimeTypeMappings = nil;
 
 @end
 
+@interface METEORCordovaURLProtocol() <NSURLSessionDelegate>
+
+@end
+
 @implementation METEORCordovaURLProtocol
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request


### PR DESCRIPTION
> /com.meteor.cordova-update/METEORCordovaURLProtocol.m:51:96: Sending 'METEORCordovaURLProtocol *const __strong' to parameter of incompatible type 'id<NSURLSessionDelegate>'
