### PR TITLE
Add CordovaUpdate.h so that other plugins can replace or extend it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings
 .idea
 *.iml
+.fetch.json

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,9 +47,10 @@
       </feature>
     </config-file>
 
-    <source-file src="src/ios/CordovaUpdate.m" />
     <header-file src="src/ios/METEORCordovaURLProtocol.h" />
     <source-file src="src/ios/METEORCordovaURLProtocol.m" />
+    <header-file src="src/ios/CordovaUpdate.h" />
+    <source-file src="src/ios/CordovaUpdate.m" />
 
     <framework src="Foundation.framework" />
 

--- a/src/ios/CordovaUpdate.h
+++ b/src/ios/CordovaUpdate.h
@@ -1,0 +1,14 @@
+/********* com.meteor.cordova-update Cordova Plugin Implementation *******/
+
+#import <Cordova/CDV.h>
+
+#import "METEORCordovaURLProtocol.h"
+
+@interface CordovaUpdate : CDVPlugin {
+}
+
+- (void)startServer:(CDVInvokedUrlCommand*)command;
+- (void)setLocalPath:(CDVInvokedUrlCommand*)command;
+
+
+@end

--- a/src/ios/CordovaUpdate.m
+++ b/src/ios/CordovaUpdate.m
@@ -1,17 +1,6 @@
 /********* com.meteor.cordova-update Cordova Plugin Implementation *******/
 
-#import <Cordova/CDV.h>
-
-#import "METEORCordovaURLProtocol.h"
-
-@interface CordovaUpdate : CDVPlugin {
-}
-
-- (void)startServer:(CDVInvokedUrlCommand*)command;
-- (void)setLocalPath:(CDVInvokedUrlCommand*)command;
-
-
-@end
+#import "CordovaUpdate.h"
 
 extern NSString *METEORDocumentRoot;
 extern NSString *METEORCordovajsRoot;


### PR DESCRIPTION
Which is what I'm doing [here](https://github.com/practicalmeteor/WKWebView/blob/meteor-wkwebview/src/ios/WkWebViewCordovaUpdate.m#L701) to be able to route CordovaUpdate.startServer to my wkwebview cordova ios plugin.
